### PR TITLE
Make hackney an optional dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Backwards incompatible changes
     - Minimum required Elixir version is now `~> 1.17`
+    - Made `:hackney` an optional dependency (applications relying on the default `UAInspector.Downloader.Adapter.Hackney` need to add it as a dependency explicitly)
 
 ## v3.12.0 (2026-02-21)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ You need to obtain a copy of the configured databases by calling either `mix ua_
 
 Refer to `UAInspector.Downloader` for more details.
 
+The default downloader adapter uses `:hackney`. Applications configuring a custom adapter (implementing the `UAInspector.Downloader.Adapter` behaviour using a different HTTP client) can omit `:hackney` because it is only an optional dependency.
+
 ### User Agent Parsing
 
 ```elixir

--- a/lib/ua_inspector/downloader/adapter.ex
+++ b/lib/ua_inspector/downloader/adapter.ex
@@ -1,6 +1,9 @@
 defmodule UAInspector.Downloader.Adapter do
   @moduledoc """
   Behaviour for modules used by the downloader.
+
+  The default adapter is `UAInspector.Downloader.Adapter.Hackney`. A custom
+  implementation can be configured using the `:downloader_adapter` option.
   """
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule UAInspector.MixProject do
       {:dialyxir, "~> 1.4", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.18.0", only: :test, runtime: false},
-      {:hackney, "~> 1.0"},
+      {:hackney, "~> 1.0", optional: true},
       {:yamerl, "~> 0.7"}
     ]
   end


### PR DESCRIPTION
Closes #42

## Motivation

Hackney 1.x currently carries a stack of unpatched security advisories (e.g. [GHSA-gp9c-pm5m-5cxr](https://github.com/advisories/GHSA-gp9c-pm5m-5cxr), GHSA-pj7v-xfvx-wmjq, GHSA-j9wq-vxxc-94wf, GHSA-mp55-p8c9-rfw2 — all fixed only in hackney 4.0.1, which is outside the current `~> 1.0` constraint). Applications that configure their own `UAInspector.Downloader.Adapter` (for example on top of Req/Finch) currently have no way to drop hackney from their dependency tree, because the dependency is declared non-optional. #42 asks for exactly this.

## Changes

- `mix.exs`: declare `{:hackney, "~> 1.0", optional: true}`
- README: document that the default adapter uses hackney and that custom-adapter applications can omit it
- CHANGELOG: note the change under `v4.0.0-dev`
- `UAInspector.Downloader.Adapter` moduledoc: point at the `:downloader_adapter` option

## Compatibility

For applications using the default `UAInspector.Downloader.Adapter.Hackney` nothing changes as long as they keep hackney in their tree; the library code itself does not reference hackney outside the default adapter module. Applications replacing the adapter can now resolve hackney away entirely. This complements #41 (supporting hackney 4.x for users who keep hackney) — with this change applied, skipping hackney altogether also becomes an option.

A follow-up worth considering would be a CI job that runs the test suite without hackney to keep the default adapter honest about its requirement.